### PR TITLE
Fix create post test

### DIFF
--- a/frontend/src/components/Post/CreatePost.jsx
+++ b/frontend/src/components/Post/CreatePost.jsx
@@ -27,7 +27,7 @@ const CreatePost = (props) => {
         props.setToken(data.token);
       })
       .catch((err) => {
-        console.err(err);
+        console.error(err);
       });
 
     setText("");

--- a/frontend/src/components/Post/CreatePost.jsx
+++ b/frontend/src/components/Post/CreatePost.jsx
@@ -12,16 +12,14 @@ const CreatePost = (props) => {
   const handleCreatePost = (event) => {
     event.preventDefault();
     // TODO:
-    // The following lines of code will never be called as <textarea> has been
-    // set to required. This makes it hard to test and so can only test that
-    // the function wasn't called.
+    // The below check won't be called <textarea> has attribute "required". 
+    // This makes it hard to test and so can only test that the function wasn't called.
     // The tooltip popup is from the browser and won't appear in the DOM
-    //
-    // if (!text.trim()) {
-    //   console.log("createPosts wasn't called")
-    //   console.error("Error: Please write some text in your post");
-    //   return;
-    // }
+    if (!text.trim()) {
+      console.log("createPosts wasn't called")
+      console.error("Error: Please write some text in your post");
+      return;
+    }
 
     createPosts(props.token, text)
       .then((data) => {

--- a/frontend/src/components/Post/CreatePost.jsx
+++ b/frontend/src/components/Post/CreatePost.jsx
@@ -15,6 +15,7 @@ const CreatePost = (props) => {
     // The below check won't be called <textarea> has attribute "required". 
     // This makes it hard to test and so can only test that the function wasn't called.
     // The tooltip popup is from the browser and won't appear in the DOM
+    // Need to have a further think about validation on front end
     if (!text.trim()) {
       console.log("createPosts wasn't called")
       console.error("Error: Please write some text in your post");

--- a/frontend/src/components/Post/CreatePost.jsx
+++ b/frontend/src/components/Post/CreatePost.jsx
@@ -4,30 +4,33 @@ import { createPosts } from "../../services/posts";
 const CreatePost = (props) => {
   // Updates the text in the body of textarea
   const [text, setText] = useState("");
-  // Need this to pass the user_id from token generated from user login
-  // to backend for authentiation when making requests
-  
+
   const handleChange = (event) => {
     setText(event.target.value);
   };
 
   const handleCreatePost = (event) => {
     event.preventDefault();
-    if (text.trim() === "") {
-      console.log("createPosts wasn't called")
-      console.error("Error: Please write some text in your post");
-      return;
-    }
-    console.log('createPosts was called')
+    // TODO:
+    // The following lines of code will never be called as <textarea> has been
+    // set to required. This makes it hard to test and so can only test that
+    // the function wasn't called.
+    // The tooltip popup is from the browser and won't appear in the DOM
+    //
+    // if (!text.trim()) {
+    //   console.log("createPosts wasn't called")
+    //   console.error("Error: Please write some text in your post");
+    //   return;
+    // }
 
     createPosts(props.token, text)
       .then((data) => {
         props.setToken(data.token);
       })
       .catch((err) => {
-        console.err(err);
+        console.error(err);
       });
-      
+
     setText("");
     //We might need to change to change to the following code when implementing Posts with Photos
     // const form = event.target;
@@ -38,8 +41,11 @@ const CreatePost = (props) => {
   };
 
   return (
-    <div role="createPostDiv" className="w-1/2 border border-gray-200 bg-gray-50">
-    <form onSubmit={handleCreatePost} aria-label="Create New Post Form">
+    <div
+      role="createPostDiv"
+      className="w-1/2 border border-gray-200 bg-gray-50"
+    >
+      <form onSubmit={handleCreatePost} aria-label="Create New Post Form">
         <div className="px-4 py-2 bg-white rounded-t-lg">
           <textarea
             name="message"

--- a/frontend/src/components/Post/Post.jsx
+++ b/frontend/src/components/Post/Post.jsx
@@ -12,6 +12,7 @@ const Post = (props) => {
               Pic
             </div>
             <div className="flex flex-col justify-center ms-4">
+              {/* TODO: Add some useful label to the below div to identify it as user's name */}
               <div className="text-sky-500 text-base font-bold">
                 {props.post.user_data[0].username} ({props.post.user_data[0].firstName} {props.post.user_data[0].lastName})
               </div>

--- a/frontend/src/services/posts.js
+++ b/frontend/src/services/posts.js
@@ -20,6 +20,7 @@ export const getPosts = async (token) => {
 };
 
 export const createPosts = async (token, message) => {
+  // console.log("createPosts was called")
   const payload = {
     message: message,
     createdAt: new Date().toISOString(),

--- a/frontend/src/services/posts.js
+++ b/frontend/src/services/posts.js
@@ -20,7 +20,6 @@ export const getPosts = async (token) => {
 };
 
 export const createPosts = async (token, message) => {
-  // console.log("createPosts was called")
   const payload = {
     message: message,
     createdAt: new Date().toISOString(),

--- a/frontend/tests/components/createPost.test.jsx
+++ b/frontend/tests/components/createPost.test.jsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, vi } from "vitest";
 import * as servicesPost from "../../src/services/posts";
-// import { createPosts } from "../../src/services/posts"
 import CreatePost from "../../src/components/Post/CreatePost";
 
 describe("CreatePost component renders correctly", () => {
@@ -33,7 +32,7 @@ describe("Create Post component functions correctly", () => {
 
   const createPostsSpy = vi
     .spyOn(servicesPost, "createPosts")
-    .mockResolvedValue(console.log("called success"));
+    .mockResolvedValue({});
 
   //TODO: Is this test necessary as it can be covered by the below test
   test("User can input text into textarea", async () => {
@@ -44,6 +43,7 @@ describe("Create Post component functions correctly", () => {
     );
   });
 
+  //TODO: props.setToken isn't a function
   test("When a user fills out the post's text field and clicks the button, it calls the createPost method with a token and a string", async () => {
     const mockToken = "testToken";
 
@@ -64,6 +64,7 @@ describe("Create Post component functions correctly", () => {
   // As the validation has been delegated to <textarea required> rather than our own checks
   // TODO: Discuss if we are ok with using <textarea required>
   test("User can't submit a post that's empty", async () => {
+    
     render(<CreatePost />);
     const submitButtonEl = screen.getByRole("createPostSubmitButton");
     userEvent.click(submitButtonEl);

--- a/frontend/tests/components/createPost.test.jsx
+++ b/frontend/tests/components/createPost.test.jsx
@@ -22,7 +22,7 @@ describe("CreatePost component renders correctly", () => {
 const completeCreatePostForm = async () => {
   const user = userEvent.setup();
   const textAreaEl = screen.getByPlaceholderText("Write a post...");
-  await user.type(textAreaEl, "Hello World");
+  await user.type(textAreaEl, "Hell o World");
 };
 
 describe("Create Post component functions correctly", () => {

--- a/frontend/tests/components/createPost.test.jsx
+++ b/frontend/tests/components/createPost.test.jsx
@@ -22,7 +22,7 @@ describe("CreatePost component renders correctly", () => {
 const completeCreatePostForm = async () => {
   const user = userEvent.setup();
   const textAreaEl = screen.getByPlaceholderText("Write a post...");
-  await user.type(textAreaEl, "Hell o World");
+  await user.type(textAreaEl, "Hello World");
 };
 
 describe("Create Post component functions correctly", () => {

--- a/frontend/tests/components/createPost.test.jsx
+++ b/frontend/tests/components/createPost.test.jsx
@@ -34,16 +34,7 @@ describe("Create Post component functions correctly", () => {
     .spyOn(servicesPost, "createPosts")
     .mockResolvedValue({});
 
-  //TODO: Is this test necessary as it can be covered by the below test
-  test("User can input text into textarea", async () => {
-    render(<CreatePost />);
-    await completeCreatePostForm();
-    expect(screen.getByPlaceholderText("Write a post...")).toHaveTextContent(
-      "Hello World"
-    );
-  });
-
-  //TODO: props.setToken isn't a function
+  //TODO: props.setToken isn't a function. Maybe need to create a mock?
   test("When a user fills out the post's text field and clicks the button, it calls the createPost method with a token and a string", async () => {
     const mockToken = "testToken";
 

--- a/frontend/tests/components/createPost.test.jsx
+++ b/frontend/tests/components/createPost.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, vi } from "vitest";
 import * as servicesPost from "../../src/services/posts";
+// import { createPosts } from "../../src/services/posts"
 import CreatePost from "../../src/components/Post/CreatePost";
 
 describe("CreatePost component renders correctly", () => {
@@ -9,8 +10,10 @@ describe("CreatePost component renders correctly", () => {
     render(<CreatePost />);
     expect(screen.getByPlaceholderText("Write a post...")).toBeInTheDocument();
     expect(screen.getByRole("createPostSubmitButton")).toBeInTheDocument();
-    expect(screen.getByRole("createPostSubmitButton")).toHaveTextContent("Create Post");
-    expect(screen.getByRole("form")).toBeInTheDocument(); 
+    expect(screen.getByRole("createPostSubmitButton")).toHaveTextContent(
+      "Create Post"
+    );
+    expect(screen.getByRole("form")).toBeInTheDocument();
     expect(screen.getByLabelText("Create New Post Form")).toBeInTheDocument();
   });
 });
@@ -23,10 +26,16 @@ const completeCreatePostForm = async () => {
   await user.type(textAreaEl, "Hello World");
 };
 
-
 describe("Create Post component functions correctly", () => {
-  const createPosts = vi.spyOn(servicesPost, 'createPosts').mockResolvedValue({});
+  beforeEach(() => {
+    createPostsSpy.mockClear();
+  });
 
+  const createPostsSpy = vi
+    .spyOn(servicesPost, "createPosts")
+    .mockResolvedValue(console.log("called success"));
+
+  //TODO: Is this test necessary as it can be covered by the below test
   test("User can input text into textarea", async () => {
     render(<CreatePost />);
     await completeCreatePostForm();
@@ -35,30 +44,36 @@ describe("Create Post component functions correctly", () => {
     );
   });
 
-  it("calls the createPosts function when user clicks button", async () => {
-    render(<CreatePost />);
+  test("When a user fills out the post's text field and clicks the button, it calls the createPost method with a token and a string", async () => {
+    const mockToken = "testToken";
+
+    render(<CreatePost token={mockToken} />);
     await completeCreatePostForm();
+    expect(screen.getByPlaceholderText("Write a post...")).toHaveTextContent(
+      "Hello World"
+    );
     const submitButtonEl = screen.getByRole("createPostSubmitButton");
     userEvent.click(submitButtonEl);
     await waitFor(() => {
-      expect(createPosts).toHaveBeenCalled();
+      expect(createPostsSpy).toHaveBeenCalled();
+      expect(createPostsSpy).toHaveBeenCalledWith(mockToken, "Hello World");
     });
   });
 
-  // This test implementation only tests that services/createPosts hasn't been called
-  // Haven't discussed the sort of error the user should recieve
-  
-  //To implement (fix)
-  /*
+  // This test implementation only tests that createPosts method hasn't been called
+  // As the validation has been delegated to <textarea required> rather than our own checks
+  // TODO: Discuss if we are ok with using <textarea required>
   test("User can't submit a post that's empty", async () => {
-    // const logSpy = vi.spyOn(console, 'error')
     render(<CreatePost />);
     const submitButtonEl = screen.getByRole("createPostSubmitButton");
     userEvent.click(submitButtonEl);
     await waitFor(() => {
-      expect(createPosts).not.toHaveBeenCalled();
-      // expect(logSpy).toHaveBeenCalled();
+      expect(createPostsSpy).not.toHaveBeenCalled();
     });
   });
-  */
+
+  //TODO:
+  test.skip("User can't submit a post that has a char length over _____", () => {
+
+  })
 });

--- a/frontend/tests/components/post.test.jsx
+++ b/frontend/tests/components/post.test.jsx
@@ -19,6 +19,7 @@ describe("Post component tests", () => {
     render(<Post post={testPost} />);
     const paragraph = screen.getByRole("singlePostContent");
     expect(paragraph.textContent).toEqual("Test Post 1");
+    // TODO: Should probably check that the names are also next to the post
   });
 
   test("displays Like component", () => {


### PR DESCRIPTION
Fixed the test for the CreatePost component. 
I added some comments for further improvements that could be added as tickets. 
I think tests can be more robust as there's nothing for error. 
The test logs props.setToken() isn't a function. Not sure if it's because it isn't receiving the function from parent component during tests. If so, maybe needs to be mocked to make it for a proper unit test. 